### PR TITLE
로컬 개발을 위한 docker 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+docker/db/data/

--- a/docker/db/conf.d/my.cnf
+++ b/docker/db/conf.d/my.cnf
@@ -3,9 +3,9 @@ default-character-set = utf8mb4
 
 [mysql]
 default-character-set = utf8mb4
-lower_case_table_names = 1
 
 [mysqld]
 character-set-client-handshake = FALSE
 character-set-server           = utf8mb4
 collation-server               = utf8mb4_unicode_ci
+lower_case_table_names = 1

--- a/docker/db/conf.d/my.cnf
+++ b/docker/db/conf.d/my.cnf
@@ -1,0 +1,11 @@
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4
+lower_case_table_names = 1
+
+[mysqld]
+character-set-client-handshake = FALSE
+character-set-server           = utf8mb4
+collation-server               = utf8mb4_unicode_ci

--- a/docker/db/initdb.d/DDL.sql
+++ b/docker/db/initdb.d/DDL.sql
@@ -1,1 +1,9 @@
-create database our_meeting;
+create database if not exists our_meeting;
+
+use our_meeting;
+
+create table if not exists test_table (
+    id int primary key auto_increment,
+    name VARCHAR(100) not null,
+    reg_dt date
+);

--- a/docker/db/initdb.d/DDL.sql
+++ b/docker/db/initdb.d/DDL.sql
@@ -1,0 +1,1 @@
+create database our_meeting;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,17 +1,17 @@
-version: "3"
+version: "3.7"
 
 services:
   db:
-    image: mysql:8.0.17
+    container_name: local-mysql
+    image: mysql:5.7
     ports:
       - "3306:3306"
     volumes:
       - ./db/conf.d:/etc/mysql/conf.d
       - ./db/data:/var/lib/mysql
-      - ./db/initdb.d:/docker-entrypoint-initdb.d
+      - ./db/initdb.d:/docker-entrypoint-initdb.d # docker image 생성시 딱 1번만 실행
     environment:
       TZ: Asiz/Seoul
-      MYSQL_ROOT_HOST: "%"
       MYSQL_DATABASE: "our_meeting"
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+
+services:
+  db:
+    image: mysql:8.0.17
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./db/conf.d:/etc/mysql/conf.d
+      - ./db/data:/var/lib/mysql
+      - ./db/initdb.d:/docker-entrypoint-initdb.d
+    environment:
+      TZ: Asiz/Seoul
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_DATABASE: "our_meeting"
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    restart: always


### PR DESCRIPTION
제가 두분 개발PC 운영체제를 못 물어봤네요. 
우선 저는 mac 에서만 테스트 해봤는데, 윈도우도 해보겠습니다.

구글링을 해서 docker를 PC에 설치를 하시고
Window 의 경우 window terminal 앱을 window app store에서 다운받으시고,
맥인 경우 terminal 을 통해서 docker 정상설치 여부를 확인할 수 있습니다.
아래와 같은 명령어를 통해 확인 가능합니다.
`docker --version`

정상 설치가 되었다면,
프로젝트경로중 /docker 디렉토리 (정확히는 docker-compose.yml 파일이 존재하는 위치)에 가서

터미널에서 아래와 같은 커맨드를 입력한뒤 엔터누르면 mysql이 설치 및 실행이 됩니다.
`docker-compose up -d`

정상 작동을 테스트 하기 위해서는 docker 내부 로그를 확인하면 됩니다. 아래와 같은 커맨드 입력&실행하세요.
`docker-compose logs -f`

로그에 특별한 에러가 없으면 정상 실행 된것입니다.
db 접속툴을 통해 정상접속 확인하면 됩니다. (db접속툴은 workbench가 무료이고, 다른것도 상관없습니다. 설치는 PC에다가 직접 설치하시면 됩니다.)

hostname: localhost
port: 3306
password: 입력X


정리하자면

1. docker 설치
2. 프로젝트내에 docker-compose.yml 파일이 있는곳에서 docker-compose 실행
3. workbench or db접속툴을 사용하여, 정상 접속확인 입니다.

**시간 나실때 확인해보시고, 로컬에서 디비 접속 테스트 끝나시면 댓글 달아주세요.
마지막에 댓글다신분이 pull request 승인해주세요.
에러나도 마찬가지로 댓글달아주시면 같이 해결해보겠습니다.**
@Cho-D-YoungRae @HMWG 


